### PR TITLE
Display validation errors when workflowrun creation fails

### DIFF
--- a/src/js/Shared/RODAN_EVENTS.js
+++ b/src/js/Shared/RODAN_EVENTS.js
@@ -478,6 +478,8 @@ class RODAN_EVENTS
         ///////////////////////////////////////////////////////////////////////////////////////
         /** Triggered when WorkflowRun created. Sends {workflowrun: WorkflowRun}. */
         this.EVENT__WORKFLOWRUN_CREATED = 'EVENT__WORKFLOWRUN_CREATED';
+        /** Triggered when WorkflowRun failed to create. Sends {workflowrun: WorkflowRun, errors: object}. */
+        this.EVENT__WORKFLOWRUN_FAILED_TO_CREATE = 'EVENT__WORKFLOWRUN_FAILED_TO_CREATE';
         /** Triggered when WorkflowRun deleted. Sends {workflowrun: WorkflowRun}. */
         this.EVENT__WORKFLOWRUN_DELETED = 'EVENT__WORKFLOWRUN_DELETED';
         /** Triggered when WorkflowRun saved. Sends {workflowrun: WorkflowRun}. */


### PR DESCRIPTION
Ticket: https://theyang.planio.com/issues/668

Proof video: https://vimeo.com/382701031 (password: rodan)

- The error from server should be displayed when there are uneven multiple-resource collections.
- The error from server should not be displayed and the workflow execution should go on when all multiple-resource collections are same in length (excluding 1-resource collections).